### PR TITLE
more safety in saveAndMergeWithMainContext

### DIFF
--- a/VOKCoreDataManager.m
+++ b/VOKCoreDataManager.m
@@ -439,9 +439,13 @@ static VOKCoreDataManager *VOK_SharedObject;
 
 - (void)tempContextSaved:(NSNotification *)notification
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
+    if ([NSOperationQueue mainQueue] == [NSOperationQueue currentQueue]) {
         [[self managedObjectContext] mergeChangesFromContextDidSaveNotification:notification];
-    });
+    } else {
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            [[self managedObjectContext] mergeChangesFromContextDidSaveNotification:notification];
+        });
+    }
 }
 
 - (NSManagedObjectContext *)temporaryContext


### PR DESCRIPTION
maybe I should make that code snippet a macro because it's typed like 10 times in VOKCoreDataManager.m 
