### PR TITLE
save main context after merging temp changes

### DIFF
--- a/VOKCoreDataManager.m
+++ b/VOKCoreDataManager.m
@@ -443,6 +443,7 @@ static VOKCoreDataManager *VOK_SharedObject;
             [[self managedObjectContext] mergeChangesFromContextDidSaveNotification:notification];
         });
     }
+    [self saveMainContextAndWait];
 }
 
 - (NSManagedObjectContext *)temporaryContext


### PR DESCRIPTION
The mainContext could become detached from the persistent store because it is rarely saved.
Previously tempContexts could become detached from the mainContext because tempContexts are siblings to the mainContext and they load from the persistent store.
