### PR TITLE
Made Core Data Manager's mapper for class public.

### DIFF
--- a/VOKCoreDataManager.h
+++ b/VOKCoreDataManager.h
@@ -86,6 +86,16 @@ typedef NS_ENUM (NSInteger, VOKMigrationFailureOption) {
  */
 - (BOOL)setObjectMapper:(VOKManagedObjectMapper *)objMap
                forClass:(Class)objectClass;
+
+/**
+ *  The VOKManagedObjectMapper for the particular class.
+ *
+ *  @param objectClass The NSManagedObject subclass that has a mapping associated with it.
+ *
+ *  @return The VOKManagedObjectMapper associated with the class.
+ */
+- (VOKManagedObjectMapper *)mapperForClass:(Class)objectClass;
+
 /**
  Deserializes the NSDictionaries full of strings and creates/updates instances in the given context.
  @param inputArray

--- a/VOKCoreDataManager.m
+++ b/VOKCoreDataManager.m
@@ -36,7 +36,6 @@
 
 //Convenience Methods
 - (NSFetchRequest *)fetchRequestWithClass:(Class)managedObjectClass predicate:(NSPredicate *)predicate;
-- (VOKManagedObjectMapper *)mapperForClass:(Class)objectClass;
 - (NSURL *)applicationLibraryDirectory;
 
 @end


### PR DESCRIPTION
Because we now have that handy `@property BOOL ignoreNullValueOverwrites`, we need the exact mapper that's associated with the class, not the global default mapper. This method already existed privately, let's make it public!
