### PR TITLE
Added check for ignoreNullValueOverwrites that was being missed.

### DIFF
--- a/VOKManagedObjectMapper.m
+++ b/VOKManagedObjectMapper.m
@@ -241,7 +241,11 @@ NSString *const period = @".";
 //using DEFAULT mapper, if the input string COULD be made a number it WILL be made a number.
         inputObject = [self checkClass:inputObject managedObject:object key:key];
         inputObject = [self checkNull:inputObject];
-        [object vok_safeSetValue:inputObject forKey:key];
+        if (!self.ignoreNullValueOverwrites) {
+            [object vok_safeSetValue:inputObject forKey:key];
+        } else if (inputObject) {
+            [object vok_safeSetValue:inputObject forKey:key];
+        }
     }];
 }
 


### PR DESCRIPTION
I thought I put this in the earlier PR but I guess it was missed. 

Just like what Sean instituted [here](https://github.com/vokalinteractive/VOKCoreDataManager/commit/54fe0147ff1cb54c0544cdaa31b7ae84520280b0), this checks for the boolean and value and acts appropriately.
